### PR TITLE
Fix packet editor logging hook

### DIFF
--- a/Timelapse/Assembly.h
+++ b/Timelapse/Assembly.h
@@ -132,25 +132,25 @@ inline bool __stdcall shouldMobBeFiltered() {
 }
 
 
-static std::queue<COutPacket*> *sendPacketQueue = new std::queue<COutPacket*>();
+static std::queue<USHORT> *sendPacketQueue = new std::queue<USHORT>();
 inline void __stdcall addSendPacket() {
-	//void* packet = new COutPacket();
-	//memcpy((void*)packet, (void*)sendPacketData->packet, sizeof(COutPacket));
-	COutPacket *packet = new COutPacket();
-	COutPacket *oldPacket = sendPacketData->packet;
+        if (sendPacketData == nullptr || sendPacketData->packet == nullptr)
+                return;
 
-	packet->Loopback = oldPacket->Loopback;
-	UCHAR data = *oldPacket->Data;
-	//void unk = *oldPacket->Unk;
-	USHORT header = *oldPacket->Header;
+        COutPacket *oldPacket = sendPacketData->packet;
+        USHORT header = 0;
 
-	packet->Data = &data;
-	packet->Unk = oldPacket->Unk;
-	packet->Header = &header;
-	packet->Size = oldPacket->Size;
-	packet->Offset = oldPacket->Offset;
-	packet->EncryptedByShanda = oldPacket->EncryptedByShanda;
-	sendPacketQueue->push(packet);
+        if (oldPacket->Header != nullptr) {
+                header = *oldPacket->Header;
+        }
+        else if (oldPacket->Data != nullptr && oldPacket->Size >= sizeof(USHORT)) {
+                header = *reinterpret_cast<PUSHORT>(oldPacket->Data);
+        }
+        else {
+                return;
+        }
+
+        sendPacketQueue->push(header);
 }
 
 #pragma unmanaged

--- a/Timelapse/Hooks.h
+++ b/Timelapse/Hooks.h
@@ -134,25 +134,25 @@ inline bool __stdcall shouldMobBeFiltered() {
 }
 
 
-static std::queue<COutPacket*> *sendPacketQueue = new std::queue<COutPacket*>();
+static std::queue<USHORT> *sendPacketQueue = new std::queue<USHORT>();
 inline void __stdcall addSendPacket() {
-	//void* packet = new COutPacket();
-	//memcpy((void*)packet, (void*)sendPacketData->packet, sizeof(COutPacket));
-	COutPacket *packet = new COutPacket();
-	COutPacket *oldPacket = sendPacketData->packet;
+        if (sendPacketData == nullptr || sendPacketData->packet == nullptr)
+                return;
 
-	packet->Loopback = oldPacket->Loopback;
-	UCHAR data = *oldPacket->Data;
-	//void unk = *oldPacket->Unk;
-	USHORT header = *oldPacket->Header;
+        COutPacket *oldPacket = sendPacketData->packet;
+        USHORT header = 0;
 
-	packet->Data = &data;
-	packet->Unk = oldPacket->Unk;
-	packet->Header = &header;
-	packet->Size = oldPacket->Size;
-	packet->Offset = oldPacket->Offset;
-	packet->EncryptedByShanda = oldPacket->EncryptedByShanda;
-	sendPacketQueue->push(packet);
+        if (oldPacket->Header != nullptr) {
+                header = *oldPacket->Header;
+        }
+        else if (oldPacket->Data != nullptr && oldPacket->Size >= sizeof(USHORT)) {
+                header = *reinterpret_cast<PUSHORT>(oldPacket->Data);
+        }
+        else {
+                return;
+        }
+
+        sendPacketQueue->push(header);
 }
 
 #pragma unmanaged

--- a/Timelapse/Hooks.h
+++ b/Timelapse/Hooks.h
@@ -4,8 +4,9 @@
 #include "GeneralFunctions.h"
 #include "Packet.h"
 #include "detours.h"
-#include <queue>
+#include "Native/PacketLogQueue.h"
 #include "Addresses.h"
+#include <vector>
 
 #pragma comment(lib, "detours.lib")
 #define CodeCave(name) static void __declspec(naked) ##name() { _asm
@@ -36,7 +37,6 @@ bool isMobLoggingEnabled = false, isMobFilterEnabled = false, isMobFilterWhiteLi
 ULONG itemLogged = 0, itemFilterMesos = 0, mobLogged = 0;
 static std::vector<ULONG> *itemList = new std::vector<ULONG>(), *mobList = new std::vector<ULONG>();
 static std::vector<SpawnControlData*> *spawnControl = new std::vector<SpawnControlData*>();
-static std::vector<COutPacket> *sendPacketLogQueue = new std::vector<COutPacket>();
 SendPacketData *sendPacketData;
 ULONG dupeXFoothold = 0;
 
@@ -134,25 +134,11 @@ inline bool __stdcall shouldMobBeFiltered() {
 }
 
 
-static std::queue<USHORT> *sendPacketQueue = new std::queue<USHORT>();
 inline void __stdcall addSendPacket() {
         if (sendPacketData == nullptr || sendPacketData->packet == nullptr)
                 return;
 
-        COutPacket *oldPacket = sendPacketData->packet;
-        USHORT header = 0;
-
-        if (oldPacket->Header != nullptr) {
-                header = *oldPacket->Header;
-        }
-        else if (oldPacket->Data != nullptr && oldPacket->Size >= sizeof(USHORT)) {
-                header = *reinterpret_cast<PUSHORT>(oldPacket->Data);
-        }
-        else {
-                return;
-        }
-
-        sendPacketQueue->push(header);
+        Timelapse::Native::EnqueueSendPacket(*sendPacketData->packet);
 }
 
 #pragma unmanaged

--- a/Timelapse/Log.cpp
+++ b/Timelapse/Log.cpp
@@ -38,17 +38,26 @@ String^ Log::GetLogPath() {
 	return LogsFilePath;
 }
 
- void Log::WriteLineToConsole(String^ str) {
-	if (String::IsNullOrEmpty(str)) return;
-	int const LOG_MAX_LINES = 200;
-	String^ strOut = gcnew String(str);
-	String^ timeNow = DateTime::Now.ToString("HH:mm::ss.fff");
-	String^ strToWrite = (timeNow + ": " + strOut);
+void Log::WriteLineToConsole(String^ str) {
+        if (String::IsNullOrEmpty(str)) return;
 
-	// add this line at the top of the log
-	MainForm::TheInstance->lbConsoleLog->Items->Insert(0, strToWrite);
-	// keep only a few lines in the log
-	while (MainForm::TheInstance->lbConsoleLog->Items->Count > LOG_MAX_LINES) {
-		MainForm::TheInstance->lbConsoleLog->Items->RemoveAt(MainForm::TheInstance->lbConsoleLog->Items->Count - 1);
-	}
+        MainForm^ mainForm = MainForm::TheInstance;
+        if (mainForm == nullptr || mainForm->lbConsoleLog == nullptr) return;
+
+        System::Windows::Forms::ListBox^ listBox = mainForm->lbConsoleLog;
+        if (listBox->InvokeRequired) {
+                listBox->BeginInvoke(gcnew System::Action<String^>(Log::WriteLineToConsole), gcnew array<Object^>{ str });
+                return;
+        }
+
+        int const LOG_MAX_LINES = 200;
+        String^ timeNow = DateTime::Now.ToString("HH:mm::ss.fff");
+        String^ strToWrite = timeNow + ": " + str;
+
+        // add this line at the top of the log
+        listBox->Items->Insert(0, strToWrite);
+        // keep only a few lines in the log
+        while (listBox->Items->Count > LOG_MAX_LINES) {
+                listBox->Items->RemoveAt(listBox->Items->Count - 1);
+        }
 }

--- a/Timelapse/MainForm.cpp
+++ b/Timelapse/MainForm.cpp
@@ -2312,15 +2312,14 @@ void MainForm::tPacketLog_Tick(System::Object^  sender, System::EventArgs^  e) {
 		this->tPacketLog->Enabled = false;
 
 	//std::vector<COutPacket*> *sentPacketQueue = Assembly::sendPacketLogQueue;
-	if(GlobalRefs::bSendPacketLog && !Assembly::sendPacketQueue->empty()) {
-		COutPacket *packet = (COutPacket*)Assembly::sendPacketQueue->front();
-		
-		String^ packetHeader = "";
-		writeUnsignedShort(packetHeader, *packet->Header);
-		Log::WriteLineToConsole(packetHeader);
-		
-		Assembly::sendPacketQueue->pop();
-	}
+        if (GlobalRefs::bSendPacketLog && !Assembly::sendPacketQueue->empty()) {
+                USHORT header = Assembly::sendPacketQueue->front();
+                Assembly::sendPacketQueue->pop();
+
+                String^ packetHeader = "";
+                writeUnsignedShort(packetHeader, header);
+                Log::WriteLineToConsole(packetHeader);
+        }
 
 	/*if(!GlobalRefs::bSendPacketLog) {
 		for (std::vector<COutPacket>::const_iterator i = Assembly::sendPacketLogQueue->begin(); i != Assembly::sendPacketLogQueue->end(); ++i) {

--- a/Timelapse/Native/PacketLogQueue.cpp
+++ b/Timelapse/Native/PacketLogQueue.cpp
@@ -1,0 +1,73 @@
+#include "Native/PacketLogQueue.h"
+
+#include <mutex>
+#include <queue>
+#include <utility>
+
+#pragma managed(push, off)
+
+namespace Timelapse {
+namespace Native {
+namespace {
+        std::mutex g_sendPacketMutex;
+        std::queue<PacketLogEntry> g_sendPacketQueue;
+
+        bool SnapshotPacket(const COutPacket& packet, PacketLogEntry& entry) {
+                if (packet.Size < sizeof(USHORT)) {
+                        return false;
+                }
+
+                const unsigned char* dataStart = nullptr;
+                if (packet.Header != nullptr) {
+                        entry.header = *packet.Header;
+                        dataStart = reinterpret_cast<const unsigned char*>(packet.Header + 1);
+                }
+                else if (packet.Data != nullptr) {
+                        const unsigned char* rawData = packet.Data;
+                        entry.header = *reinterpret_cast<const USHORT*>(rawData);
+                        dataStart = rawData + sizeof(USHORT);
+                }
+                else {
+                        return false;
+                }
+
+                const size_t payloadSize = packet.Size > sizeof(USHORT)
+                        ? static_cast<size_t>(packet.Size - sizeof(USHORT))
+                        : 0;
+                entry.payload.assign(dataStart, dataStart + payloadSize);
+                return true;
+        }
+}
+
+void EnqueueSendPacket(const COutPacket& packet) {
+        PacketLogEntry entry{};
+        if (!SnapshotPacket(packet, entry)) {
+                return;
+        }
+
+        std::lock_guard<std::mutex> lock(g_sendPacketMutex);
+        g_sendPacketQueue.push(std::move(entry));
+}
+
+bool TryDequeueSendPacket(PacketLogEntry& entry) {
+        std::lock_guard<std::mutex> lock(g_sendPacketMutex);
+        if (g_sendPacketQueue.empty()) {
+                return false;
+        }
+
+        entry = std::move(g_sendPacketQueue.front());
+        g_sendPacketQueue.pop();
+        return true;
+}
+
+void ClearSendPackets() {
+        std::lock_guard<std::mutex> lock(g_sendPacketMutex);
+        std::queue<PacketLogEntry> empty;
+        std::swap(g_sendPacketQueue, empty);
+}
+
+} // namespace Native
+} // namespace Timelapse
+
+#pragma managed(pop)
+

--- a/Timelapse/Native/PacketLogQueue.h
+++ b/Timelapse/Native/PacketLogQueue.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <vector>
+#include "Structs.h"
+
+namespace Timelapse {
+namespace Native {
+
+struct PacketLogEntry {
+        USHORT header;
+        std::vector<unsigned char> payload;
+};
+
+void EnqueueSendPacket(const COutPacket& packet);
+bool TryDequeueSendPacket(PacketLogEntry& entry);
+void ClearSendPackets();
+
+} // namespace Native
+} // namespace Timelapse
+

--- a/Timelapse/Timelapse.vcxproj
+++ b/Timelapse/Timelapse.vcxproj
@@ -140,6 +140,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Inventory.cpp" />
+    <ClCompile Include="Native\PacketLogQueue.cpp" />
     <ClCompile Include="Log.cpp" />
     <ClCompile Include="MainForm.cpp" />
     <ClCompile Include="Mouse.cpp" />
@@ -152,6 +153,7 @@
     <ClInclude Include="GeneralFunctions.h" />
     <ClInclude Include="Inventory.h" />
     <ClInclude Include="Log.h" />
+    <ClInclude Include="Native\PacketLogQueue.h" />
     <ClInclude Include="Macro.h" />
     <ClInclude Include="MapleFunctions.h" />
     <ClInclude Include="Memory.h" />

--- a/Timelapse/Timelapse.vcxproj.filters
+++ b/Timelapse/Timelapse.vcxproj.filters
@@ -5,9 +5,15 @@
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
       <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
+    <Filter Include="Source Files\Native">
+      <UniqueIdentifier>{CC1FDBFD-2A17-44F6-8F0B-CDF70B87BC56}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Header Files\Native">
+      <UniqueIdentifier>{2208F034-E3A7-4E8D-B8E5-F28524759E41}</UniqueIdentifier>
     </Filter>
     <Filter Include="Resource Files">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
@@ -41,6 +47,9 @@
     </ClInclude>
     <ClInclude Include="Log.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Native\PacketLogQueue.h">
+      <Filter>Header Files\Native</Filter>
     </ClInclude>
     <ClInclude Include="Mouse.h">
       <Filter>Header Files</Filter>
@@ -82,6 +91,9 @@
     </ClCompile>
     <ClCompile Include="Inventory.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Native\PacketLogQueue.cpp">
+      <Filter>Source Files\Native</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- snapshot send packet headers in the logging hook instead of queuing dangling COutPacket pointers
- update the packet log timer to read the stored headers and push them to the console

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6f6b102508332bd8d4caa84211b71