### PR TITLE
Disable macro text inputs while active and replace TextChanged hooks

### DIFF
--- a/Timelapse/Application/MainForm.cpp
+++ b/Timelapse/Application/MainForm.cpp
@@ -574,12 +574,21 @@ static bool isKeyValid(Object^ sender, Windows::Forms::KeyPressEventArgs^ e, boo
 }
 #pragma region Auto HP
 void MainForm::cbHP_CheckedChanged(Object^  sender, EventArgs^  e) {
-	if (this->cbHP->Checked) {
-		if (GlobalRefs::macroHP == nullptr)
-			GlobalRefs::macroHP = gcnew Macro(keyCollection[this->comboHPKey->SelectedIndex], Convert::ToUInt32(HPPotDelay->Text), MacroType::HPPOTMACRO);
-		GlobalRefs::macroHP->Toggle(true);
-		MacrosEnabled::bMacroHP = true;
-	}
+        const bool inputsEnabled = !this->cbHP->Checked;
+        this->tbHP->Enabled = inputsEnabled;
+        this->HPPotDelay->Enabled = inputsEnabled;
+
+        if (this->cbHP->Checked) {
+                if (String::IsNullOrWhiteSpace(tbHP->Text) || String::IsNullOrWhiteSpace(HPPotDelay->Text)) {
+                        MessageBox::Show("Error: HP Pot textboxes cannot be empty");
+                        this->cbHP->Checked = false;
+                        return;
+                }
+                if (GlobalRefs::macroHP == nullptr)
+                        GlobalRefs::macroHP = gcnew Macro(keyCollection[this->comboHPKey->SelectedIndex], Convert::ToUInt32(HPPotDelay->Text), MacroType::HPPOTMACRO);
+                GlobalRefs::macroHP->Toggle(true);
+                MacrosEnabled::bMacroHP = true;
+        }
 	else {
 		GlobalRefs::macroHP->Toggle(false);
 		MacrosEnabled::bMacroHP = false;
@@ -598,12 +607,21 @@ void MainForm::tbHP_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^
 
 #pragma region Auto MP
 void MainForm::cbMP_CheckedChanged(Object^  sender, EventArgs^  e) {
-	if (this->cbMP->Checked) {
-		if (GlobalRefs::macroMP == nullptr){}
-			GlobalRefs::macroMP = gcnew Macro(keyCollection[this->comboMPKey->SelectedIndex], Convert::ToUInt32(MPPotDelay->Text), MacroType::MPPOTMACRO);
-		GlobalRefs::macroMP->Toggle(true);
-		MacrosEnabled::bMacroMP = true;
-	}
+        const bool inputsEnabled = !this->cbMP->Checked;
+        this->tbMP->Enabled = inputsEnabled;
+        this->MPPotDelay->Enabled = inputsEnabled;
+
+        if (this->cbMP->Checked) {
+                if (String::IsNullOrWhiteSpace(tbMP->Text) || String::IsNullOrWhiteSpace(MPPotDelay->Text)) {
+                        MessageBox::Show("Error: MP Pot textboxes cannot be empty");
+                        this->cbMP->Checked = false;
+                        return;
+                }
+                if (GlobalRefs::macroMP == nullptr){}
+                        GlobalRefs::macroMP = gcnew Macro(keyCollection[this->comboMPKey->SelectedIndex], Convert::ToUInt32(MPPotDelay->Text), MacroType::MPPOTMACRO);
+                GlobalRefs::macroMP->Toggle(true);
+                MacrosEnabled::bMacroMP = true;
+        }
 	else {
 		GlobalRefs::macroMP->Toggle(false);
 		MacrosEnabled::bMacroMP = false;
@@ -622,18 +640,20 @@ void MainForm::tbMP_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^
 
 #pragma region Auto Attack
 void MainForm::cbAttack_CheckedChanged(Object^  sender, EventArgs^  e) {
-	if(this->cbAttack->Checked) {
-		if(GlobalRefs::macroAttack == nullptr) {
-			if (String::IsNullOrWhiteSpace(tbAttackInterval->Text)) {
-				MessageBox::Show("Error: Attack Interval textbox cannot be empty");
-				this->cbAttack->Checked = false;
-				return;
-			}
-		}
-		this->tAutoAttack->Interval = Convert::ToInt32(tbAttackInterval->Text);
-		this->tAutoAttack->Enabled = true; //cbAttack->Checked
-		MacrosEnabled::bMacroAttack = true;
-	}
+        const bool inputsEnabled = !this->cbAttack->Checked;
+        this->tbAttackInterval->Enabled = inputsEnabled;
+        this->tbAttackMob->Enabled = inputsEnabled;
+
+        if(this->cbAttack->Checked) {
+                if (String::IsNullOrWhiteSpace(tbAttackInterval->Text)) {
+                        MessageBox::Show("Error: Attack Interval textbox cannot be empty");
+                        this->cbAttack->Checked = false;
+                        return;
+                }
+                this->tAutoAttack->Interval = Convert::ToInt32(tbAttackInterval->Text);
+                this->tAutoAttack->Enabled = true; //cbAttack->Checked
+                MacrosEnabled::bMacroAttack = true;
+        }
 	else {
 		this->tAutoAttack->Enabled = false;
 		MacrosEnabled::bMacroAttack = false;
@@ -650,16 +670,6 @@ void MainForm::tAutoAttack_Tick(Object^ sender, EventArgs^ e) {
 	}
 }
 
-void MainForm::tbAttackInterval_TextChanged(Object^  sender, EventArgs^  e) {
-	if (GlobalRefs::macroAttack != nullptr) {
-		if (String::IsNullOrWhiteSpace(tbAttackInterval->Text)) {
-			MessageBox::Show("Error: Attack Interval textbox cannot be empty");
-			return;
-		}
-		GlobalRefs::macroAttack->delay = Convert::ToUInt32(tbAttackInterval->Text);
-	}
-}
-
 void MainForm::tbAttackMob_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
@@ -672,18 +682,20 @@ void MainForm::comboAttackKey_SelectedIndexChanged(Object^  sender, EventArgs^  
 
 #pragma region Auto Loot
 void MainForm::cbLoot_CheckedChanged(Object^  sender, EventArgs^  e) {
-	if (this->cbLoot->Checked) {
-		if (GlobalRefs::macroLoot == nullptr) {
-			if (String::IsNullOrWhiteSpace(tbLootInterval->Text)) {
-				MessageBox::Show("Error: Loot Interval textbox cannot be empty");
-				this->cbLoot->Checked = false;
-				return;
-			}
-		}
-		this->tAutoLoot->Interval = Convert::ToInt32(tbAttackInterval->Text);
-		this->tAutoLoot->Enabled = true; //cbLoot->Checked
-		MacrosEnabled::bMacroLoot = true;
-	}
+        const bool inputsEnabled = !this->cbLoot->Checked;
+        this->tbLootInterval->Enabled = inputsEnabled;
+        this->tbLootItem->Enabled = inputsEnabled;
+
+        if (this->cbLoot->Checked) {
+                if (String::IsNullOrWhiteSpace(tbLootInterval->Text)) {
+                        MessageBox::Show("Error: Loot Interval textbox cannot be empty");
+                        this->cbLoot->Checked = false;
+                        return;
+                }
+                this->tAutoLoot->Interval = Convert::ToInt32(tbLootInterval->Text);
+                this->tAutoLoot->Enabled = true; //cbLoot->Checked
+                MacrosEnabled::bMacroLoot = true;
+        }
 	else {
 		this->tAutoLoot->Enabled = false; 
 		MacrosEnabled::bMacroLoot = false;
@@ -697,16 +709,6 @@ void MainForm::tbLootInterval_KeyPress(Object^  sender, Windows::Forms::KeyPress
 void MainForm::tAutoLoot_Tick(System::Object^  sender, System::EventArgs^  e) {
 	if (HelperFuncs::ValidToLoot()) {
 		KeyMacro::SpamPressKey(keyCollection[this->comboLootKey->SelectedIndex], 2);
-	}
-}
-
-void MainForm::tbLootInterval_TextChanged(Object^  sender, EventArgs^  e) {
-	if (GlobalRefs::macroLoot != nullptr) {
-		if (String::IsNullOrWhiteSpace(tbLootInterval->Text)) {
-			MessageBox::Show("Error: Loot Interval textbox cannot be empty");
-			return;
-		}
-		GlobalRefs::macroLoot->delay = Convert::ToUInt32(tbLootInterval->Text);
 	}
 }
 
@@ -1125,22 +1127,25 @@ void MainForm::tbAttackDelay_KeyPress(Object^  sender, Windows::Forms::KeyPressE
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 
-void MainForm::tbAttackDelay_TextChanged(Object^ sender, EventArgs^ e) {
-	String^ animDelayStr = tbAttackDelay->Text;
-	if (String::IsNullOrWhiteSpace(animDelayStr)) {
-		MessageBox::Show("Error: Attack delay textbox cannot be empty");
-		return;
-	}
+void MainForm::tbAttackDelay_Leave(Object^ sender, EventArgs^ e) {
+        String^ animDelayStr = tbAttackDelay->Text;
+        if (String::IsNullOrWhiteSpace(animDelayStr)) {
+                MessageBox::Show("Error: Attack delay textbox cannot be empty");
+                tbAttackDelay->Text = "0";
+                Assembly::animDelay = 0;
+                return;
+        }
 
-	const int animDelayInt = Convert::ToInt32(animDelayStr);
-	if (animDelayInt < -128) {
-		tbAttackDelay->Text = "-128";
-		Assembly::animDelay = -128;
-	} else if (animDelayInt > 127) {
-		tbAttackDelay->Text = "127";
-		Assembly::animDelay = 127;
-	}
-	Assembly::animDelay = animDelayInt;
+        int animDelayInt = Convert::ToInt32(animDelayStr);
+        if (animDelayInt < -128) {
+                animDelayInt = -128;
+        }
+        else if (animDelayInt > 127) {
+                animDelayInt = 127;
+        }
+
+        tbAttackDelay->Text = animDelayInt.ToString();
+        Assembly::animDelay = animDelayInt;
 }
 
 //TODO: the value is a byte thus should be settable in range of -128_127
@@ -1719,8 +1724,9 @@ void MainForm::bDupeXGetFoothold_Click(System::Object^  sender, System::EventArg
 	tbDupeXFoothold->Text = Convert::ToString(ReadMultiPointerSigned(UserLocalBase, 2, OFS_pID, OFS_Foothold)); 
 }
 
-void MainForm::tbDupeXFoothold_TextChanged(System::Object^  sender, System::EventArgs^  e) {
-	if (tbDupeXFoothold->Text != "") Assembly::dupeXFoothold = Convert::ToInt32(tbDupeXFoothold->Text); 
+void MainForm::tbDupeXFoothold_Leave(System::Object^  sender, System::EventArgs^  e) {
+        if (!String::IsNullOrWhiteSpace(tbDupeXFoothold->Text))
+                Assembly::dupeXFoothold = Convert::ToInt32(tbDupeXFoothold->Text);
 }
 
 void MainForm::tbDupeXFoothold_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e) {
@@ -1967,18 +1973,24 @@ void MainForm::bItemSearchLogClear_Click(System::Object^  sender, System::EventA
 }
 
 //Find items in ItemsList resource with names starting with text entered so far
-void MainForm::tbItemFilterSearch_TextChanged(System::Object^  sender, System::EventArgs^  e) {
-	lbItemSearchLog->Items->Clear();
-	findItemsStartingWithStr(tbItemFilterSearch->Text);
+void MainForm::tbItemFilterSearch_KeyUp(System::Object^  sender, System::Windows::Forms::KeyEventArgs^  e) {
+        lbItemSearchLog->Items->Clear();
+        findItemsStartingWithStr(tbItemFilterSearch->Text);
 }
 
 //Changes limit for Mesos (Range: 0<=limit<=50000)
-void MainForm::tbItemFilterMesos_TextChanged(System::Object^  sender, System::EventArgs^  e) {
-	if (!String::IsNullOrEmpty(tbItemFilterMesos->Text)) {
-		ULONG mesosLimit = Convert::ToUInt32(tbItemFilterMesos->Text);
-		if (mesosLimit >= 0 && mesosLimit <= 50000)
-			Assembly::itemFilterMesos = mesosLimit;
-	}
+void MainForm::tbItemFilterMesos_Leave(System::Object^  sender, System::EventArgs^  e) {
+        if (String::IsNullOrWhiteSpace(tbItemFilterMesos->Text)) {
+                tbItemFilterMesos->Text = Assembly::itemFilterMesos.ToString();
+                return;
+        }
+
+        ULONG mesosLimit = Convert::ToUInt32(tbItemFilterMesos->Text);
+        if (mesosLimit > 50000)
+                mesosLimit = 50000;
+
+        Assembly::itemFilterMesos = mesosLimit;
+        tbItemFilterMesos->Text = mesosLimit.ToString();
 }
 
 void MainForm::tbItemFilterID_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
@@ -2120,9 +2132,9 @@ void MainForm::bMobSearchLogClear_Click(System::Object^  sender, System::EventAr
 }
 
 //Searches MobList resource for mobs starting with text entered so far
-void MainForm::tbMobFilterSearch_TextChanged(System::Object^  sender, System::EventArgs^  e) {
-	lbMobSearchLog->Items->Clear();
-	findMobsStartingWithStr(tbMobFilterSearch->Text);
+void MainForm::tbMobFilterSearch_KeyUp(System::Object^  sender, System::Windows::Forms::KeyEventArgs^  e) {
+        lbMobSearchLog->Items->Clear();
+        findMobsStartingWithStr(tbMobFilterSearch->Text);
 }
 
 void MainForm::tbMobFilterID_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
@@ -2201,10 +2213,9 @@ void MainForm::comboToTown_SelectedIndexChanged(System::Object^  sender, System:
 	}	
 }
 
-void MainForm::comboInUseSlot_TextChanged(System::Object^  sender, System::EventArgs^  e) {
-	if (String::IsNullOrWhiteSpace(comboInUseSlot->Text)) return;
-	const int useSlot = Convert::ToInt32(comboInUseSlot->Text);
-	useSlotG = useSlot;
+void MainForm::comboInUseSlot_Leave(System::Object^  sender, System::EventArgs^  e) {
+        if (String::IsNullOrWhiteSpace(comboInUseSlot->Text)) return;
+        useSlotG = Convert::ToInt32(comboInUseSlot->Text);
 }
 
 String^ CreateRtrnScrollPacket(int scrollId, int useSlot) {
@@ -2282,43 +2293,29 @@ void MainForm::bSendRestore127Health_Click(System::Object^  sender, System::Even
 void MainForm::tbAPLevel_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
-void MainForm::tbAPLevel_TextChanged(System::Object^ sender, System::EventArgs^ e){
-}
 
 void MainForm::tbAPHP_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
-}
-void MainForm::tbAPHP_TextChanged(System::Object^ sender, System::EventArgs^ e) {
 }
 
 void MainForm::tbAPMP_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
-void MainForm::tbAPMP_TextChanged(System::Object^ sender, System::EventArgs^ e) {
-}
 
 void MainForm::tbAPSTR_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
-}
-void MainForm::tbAPSTR_TextChanged(System::Object^ sender, System::EventArgs^ e) {
 }
 
 void MainForm::tbAPDEX_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
-void MainForm::tbAPDEX_TextChanged(System::Object^ sender, System::EventArgs^ e) {
-}
 
 void MainForm::tbAPINT_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
-void MainForm::tbAPINT_TextChanged(System::Object^ sender, System::EventArgs^ e) {
-}
 
 void MainForm::tbAPLUK_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
-}
-void MainForm::tbAPLUK_TextChanged(System::Object^ sender, System::EventArgs^ e) {
 }
 
 System::Void MainForm::cbAP_CheckedChanged(System::Object^ sender, System::EventArgs^ e) {
@@ -2851,20 +2848,11 @@ void MainForm::lvMapRusherSearch_MouseDoubleClick(System::Object^  sender, Syste
 }
 
 //Find maps with names starting with text entered so far
-void MainForm::tbMapRusherSearch_TextChanged(System::Object^  sender, System::EventArgs^  e) {
-	lvMapRusherSearch->Items->Clear();
+void MainForm::tbMapRusherSearch_KeyUp(System::Object^  sender, System::Windows::Forms::KeyEventArgs^  e) {
+        lvMapRusherSearch->Items->Clear();
 
-	if(tbMapRusherSearch->Text != "")
-		findMapNamesStartingWithStr(tbMapRusherSearch->Text);
-}
-
-//Changes color of text to show that the text has changed
-void MainForm::lbMapRusherStatus_TextChanged(System::Object^  sender, System::EventArgs^  e) {	
-	lbMapRusherStatus->ForeColor = Color::DimGray;
-	Application::DoEvents();
-	Sleep(50);
-	lbMapRusherStatus->ForeColor = Color::White;
-	Application::DoEvents();
+        if(tbMapRusherSearch->Text != "")
+                findMapNamesStartingWithStr(tbMapRusherSearch->Text);
 }
 #pragma endregion
 

--- a/Timelapse/Application/MainForm.h
+++ b/Timelapse/Application/MainForm.h
@@ -2954,7 +2954,6 @@ public:
 			this->HPPotDelay->TabIndex = 13;
 			this->HPPotDelay->Text = L"500";
 			this->HPPotDelay->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->HPPotDelay->TextChanged += gcnew System::EventHandler(this, &MainForm::HPPotDelay_TextChanged);
 			// 
 			// label93
 			// 
@@ -3757,7 +3756,7 @@ public:
 			this->tbAttackDelay->TabIndex = 47;
 			this->tbAttackDelay->Text = L"10";
 			this->tbAttackDelay->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAttackDelay->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAttackDelay_TextChanged);
+                        this->tbAttackDelay->Leave += gcnew System::EventHandler(this, &MainForm::tbAttackDelay_Leave);
 			// 
 			// label89
 			// 
@@ -4774,7 +4773,7 @@ public:
 			this->tbDupeXFoothold->TabIndex = 16;
 			this->tbDupeXFoothold->Text = L"0";
 			this->tbDupeXFoothold->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbDupeXFoothold->TextChanged += gcnew System::EventHandler(this, &MainForm::tbDupeXFoothold_TextChanged);
+                        this->tbDupeXFoothold->Leave += gcnew System::EventHandler(this, &MainForm::tbDupeXFoothold_Leave);
 			this->tbDupeXFoothold->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbDupeXFoothold_KeyPress);
 			// 
 			// label60
@@ -5266,7 +5265,7 @@ public:
 			this->tbMobFilterSearch->Size = System::Drawing::Size(87, 21);
 			this->tbMobFilterSearch->TabIndex = 27;
 			this->tbMobFilterSearch->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbMobFilterSearch->TextChanged += gcnew System::EventHandler(this, &MainForm::tbMobFilterSearch_TextChanged);
+                        this->tbMobFilterSearch->KeyUp += gcnew System::Windows::Forms::KeyEventHandler(this, &MainForm::tbMobFilterSearch_KeyUp);
 			// 
 			// rbMobFilterBlackList
 			// 
@@ -5439,7 +5438,7 @@ public:
 			this->tbItemFilterSearch->Size = System::Drawing::Size(87, 21);
 			this->tbItemFilterSearch->TabIndex = 27;
 			this->tbItemFilterSearch->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbItemFilterSearch->TextChanged += gcnew System::EventHandler(this, &MainForm::tbItemFilterSearch_TextChanged);
+                        this->tbItemFilterSearch->KeyUp += gcnew System::Windows::Forms::KeyEventHandler(this, &MainForm::tbItemFilterSearch_KeyUp);
 			// 
 			// label74
 			// 
@@ -5499,7 +5498,7 @@ public:
 			this->tbItemFilterMesos->TabIndex = 22;
 			this->tbItemFilterMesos->Text = L"0";
 			this->tbItemFilterMesos->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbItemFilterMesos->TextChanged += gcnew System::EventHandler(this, &MainForm::tbItemFilterMesos_TextChanged);
+                        this->tbItemFilterMesos->Leave += gcnew System::EventHandler(this, &MainForm::tbItemFilterMesos_Leave);
 			this->tbItemFilterMesos->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbItemFilterMesos_KeyPress);
 			// 
 			// label70
@@ -5889,7 +5888,7 @@ public:
 			this->comboInUseSlot->TabIndex = 28;
 			this->comboInUseSlot->Text = L"1";
 			this->comboInUseSlot->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->comboInUseSlot->TextChanged += gcnew System::EventHandler(this, &MainForm::comboInUseSlot_TextChanged);
+                        this->comboInUseSlot->Leave += gcnew System::EventHandler(this, &MainForm::comboInUseSlot_Leave);
 			// 
 			// lbInUseSlot
 			// 
@@ -6011,7 +6010,6 @@ public:
 			this->tbAPDEX->TabIndex = 10;
 			this->tbAPDEX->Text = L"0";
 			this->tbAPDEX->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAPDEX->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAPDEX_TextChanged);
 			// 
 			// tbAPLUK
 			// 
@@ -6025,7 +6023,6 @@ public:
 			this->tbAPLUK->TabIndex = 14;
 			this->tbAPLUK->Text = L"0";
 			this->tbAPLUK->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAPLUK->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAPLUK_TextChanged);
 			// 
 			// tbAPINT
 			// 
@@ -6039,7 +6036,6 @@ public:
 			this->tbAPINT->TabIndex = 17;
 			this->tbAPINT->Text = L"0";
 			this->tbAPINT->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAPINT->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAPINT_TextChanged);
 			// 
 			// label38
 			// 
@@ -6083,7 +6079,6 @@ public:
 			this->tbAPSTR->TabIndex = 12;
 			this->tbAPSTR->Text = L"0";
 			this->tbAPSTR->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAPSTR->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAPSTR_TextChanged);
 			// 
 			// label35
 			// 
@@ -6107,7 +6102,6 @@ public:
 			this->tbAPMP->TabIndex = 9;
 			this->tbAPMP->Text = L"0";
 			this->tbAPMP->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAPMP->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAPMP_TextChanged);
 			// 
 			// label34
 			// 
@@ -6131,7 +6125,6 @@ public:
 			this->tbAPHP->TabIndex = 11;
 			this->tbAPHP->Text = L"0";
 			this->tbAPHP->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAPHP->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAPHP_TextChanged);
 			// 
 			// label33
 			// 
@@ -6165,7 +6158,6 @@ public:
 			this->tbAPLevel->TabIndex = 6;
 			this->tbAPLevel->Text = L"120";
 			this->tbAPLevel->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAPLevel->TextChanged += gcnew System::EventHandler(this, &MainForm::tbAPLevel_TextChanged);
 			// 
 			// cbAP
 			// 
@@ -6317,7 +6309,6 @@ public:
 			this->lbMapRusherStatus->TabIndex = 37;
 			this->lbMapRusherStatus->Text = L"Status: Waiting...                                                               "
 				L"                                 \r\n";
-			this->lbMapRusherStatus->TextChanged += gcnew System::EventHandler(this, &MainForm::lbMapRusherStatus_TextChanged);
 			// 
 			// tbMapRusherDestination
 			// 
@@ -6410,7 +6401,7 @@ public:
 			this->tbMapRusherSearch->Size = System::Drawing::Size(134, 21);
 			this->tbMapRusherSearch->TabIndex = 32;
 			this->tbMapRusherSearch->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbMapRusherSearch->TextChanged += gcnew System::EventHandler(this, &MainForm::tbMapRusherSearch_TextChanged);
+                        this->tbMapRusherSearch->KeyUp += gcnew System::Windows::Forms::KeyEventHandler(this, &MainForm::tbMapRusherSearch_KeyUp);
 			// 
 			// label78
 			// 
@@ -6608,10 +6599,8 @@ public:
 	private: System::Void comboMPKey_SelectedIndexChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbAttack_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void comboAttackKey_SelectedIndexChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAttackInterval_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void cbLoot_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbLootInterval_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void comboLootKey_SelectedIndexChanged(System::Object^  sender, System::EventArgs^  e);
+        private: System::Void cbLoot_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
+        private: System::Void comboLootKey_SelectedIndexChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bBuffAdd_Click(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bBuffEnableAll_Click(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bBuffDisableAll_Click(System::Object^  sender, System::EventArgs^  e);
@@ -6743,14 +6732,13 @@ public:
 	private: System::Void cbMobFilterLog_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bMobSearchLogClear_Click(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bMobFilterAdd_Click(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbMobFilterSearch_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbItemFilterSearch_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbItemFilterMesos_TextChanged(System::Object^  sender, System::EventArgs^  e);
+        private: System::Void tbMobFilterSearch_KeyUp(System::Object^  sender, System::Windows::Forms::KeyEventArgs^  e);
+        private: System::Void tbItemFilterSearch_KeyUp(System::Object^  sender, System::Windows::Forms::KeyEventArgs^  e);
+        private: System::Void tbItemFilterMesos_Leave(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void tvMapRusherSearch_MouseDoubleClick(System::Object^  sender, System::Windows::Forms::MouseEventArgs^  e);
 	private: System::Void lvMapRusherSearch_MouseDoubleClick(System::Object^  sender, System::Windows::Forms::MouseEventArgs^  e);
-	private: System::Void tbMapRusherSearch_TextChanged(System::Object^  sender, System::EventArgs^  e);
+        private: System::Void tbMapRusherSearch_KeyUp(System::Object^  sender, System::Windows::Forms::KeyEventArgs^  e);
 	private: System::Void bMapRush_Click(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void lbMapRusherStatus_TextChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbNoWalkingFriction_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbVacForceRight_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbVacJumpRight_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
@@ -6762,7 +6750,7 @@ public:
 	private: System::Void cbUEMI_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bUEMIGetCurrentLocation_Click(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbSellAll_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAttackDelay_TextChanged(System::Object^  sender, System::EventArgs^  e);
+        private: System::Void tbAttackDelay_Leave(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void embedMSWindowToolStripMenuItem_Click(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void lbConsoleLog_KeyDown(System::Object^  sender, System::Windows::Forms::KeyEventArgs^  e);
 	private: System::Void hideMSWindowToolStripMenuItem_Click(System::Object^  sender, System::EventArgs^  e);
@@ -6771,23 +6759,14 @@ public:
 	private: System::Void tAutoAttack_Tick(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void tAutoLoot_Tick(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bUseRtrnScroll_Click(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAPLevel_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAPHP_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAPMP_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAPSTR_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAPDEX_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAPINT_TextChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void tbAPLUK_TextChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbAP_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
-	private: System::Void comboInUseSlot_TextChanged(System::Object^  sender, System::EventArgs^  e);
+        private: System::Void comboInUseSlot_Leave(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbDupeX_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void tbDupeXFoothold_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
-	private: System::Void tbDupeXFoothold_TextChanged(System::Object^  sender, System::EventArgs^  e);
+        private: System::Void tbDupeXFoothold_Leave(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void bDupeXGetFoothold_Click(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void pauseMSToolStripMenuItem_Click(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void cbAutoLogin_CheckedChanged(System::Object^  sender, System::EventArgs^  e);
 	private: System::Void tPacketLog_Tick(System::Object^  sender, System::EventArgs^  e);
-private: System::Void HPPotDelay_TextChanged(System::Object^ sender, System::EventArgs^ e) {
-}
 };
 };


### PR DESCRIPTION
## Summary
- disable the HP/MP/attack/loot text boxes when their features are toggled on and validate empty inputs before enabling them
- replace the old TextChanged handlers with leave/key-up events for attack delay, filters, DupeX foothold, map search, and return-scroll slot updates
- clamp the attack delay textbox on focus loss and ensure auto loot uses its own interval value

## Testing
- not run (not supported)


------
https://chatgpt.com/codex/tasks/task_e_68d6fcf173c48332a520b8040441c8a0