### PR TITLE
Rename mob count text boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A MapleStory v83 Trainer
 - All readpointers/readmultipointers pointer functions should return integer values, caller function should convert to string. Only applicable to number values, not text values
 - Look into disabling textbox values if something is checked, also remove all textChanged events
 - Fix aesthetics of listviews (accommodating for vertical scrollbars), and make sure all listview code is identical in terms of adding/deleting/searching
-- Look into changing names of certain textboxes to add Count (ie tbLootItem should be tbLootItemCount)
+- Look into changing names of certain textboxes to add a Count suffix where appropriate
 - Look into changing names of all textboxes with name "interval" to "delay", makes more sense
 - For all new number only textboxes, double check to see if the keypress event (in MainForm.h) is defined
 - Check to make sure all char arrays are textual and unsigned char are for memory usage

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A MapleStory v83 Trainer
 - Code console for output of various logging streams
 ##### AutoCC/CS
 - (ADD) Add option for auto face left/right after cc/cs
-- Fix AutoCC tbCCCSTime, tbCCCSPeople, tbCCCSAttack, tbCCCSMob being possibly empty/null (add error message) :: if time/people == 0, change to 1
+- Fix AutoCC tbCCCSTime, tbCCCSPeople, tbCCCSAttack, tbCCCSMobCount being possibly empty/null (add error message) :: if time/people == 0, change to 1
 - Fix Auto CS function call (doesn't work as intended, get rid of blue box popup on MigrateToCashShop Call)
 - Make Auto CC/CS run on threads instead of timers. Timers cause the trainer to hang up 
 - Add option to select witch channels should be used as random choice of AutoCC and which should be prohibited from entering
@@ -87,7 +87,7 @@ A MapleStory v83 Trainer
 - All readpointers/readmultipointers pointer functions should return integer values, caller function should convert to string. Only applicable to number values, not text values
 - Look into disabling textbox values if something is checked, also remove all textChanged events
 - Fix aesthetics of listviews (accommodating for vertical scrollbars), and make sure all listview code is identical in terms of adding/deleting/searching
-- Look into changing names of certain textboxes to add Count (ie tbHPMob should be tbHPMobCount)
+- Look into changing names of certain textboxes to add Count (ie tbLootItem should be tbLootItemCount)
 - Look into changing names of all textboxes with name "interval" to "delay", makes more sense
 - For all new number only textboxes, double check to see if the keypress event (in MainForm.h) is defined
 - Check to make sure all char arrays are textual and unsigned char are for memory usage

--- a/Timelapse/Application/Macro.h
+++ b/Timelapse/Application/Macro.h
@@ -203,8 +203,8 @@ ref class Macro {
 			break;
 			case MacroType::ATTACKMACRO:
 				if (MacrosEnabled::bMacroAttack && HelperFuncs::ValidToAttack()) {
-					if (String::IsNullOrWhiteSpace(Timelapse::MainForm::TheInstance->tbAttackMob->Text)) break;
-					const int mobCntAttackLimit = Convert::ToUInt32(Timelapse::MainForm::TheInstance->tbAttackMob->Text);
+					if (String::IsNullOrWhiteSpace(Timelapse::MainForm::TheInstance->tbAttackMobCount->Text)) break;
+					const int mobCntAttackLimit = Convert::ToUInt32(Timelapse::MainForm::TheInstance->tbAttackMobCount->Text);
 					const int mobCntCurrent = ReadPointer(MobPoolBase, OFS_MobCount);
 
 					if (mobCntCurrent > mobCntAttackLimit) {

--- a/Timelapse/Application/Macro.h
+++ b/Timelapse/Application/Macro.h
@@ -191,8 +191,8 @@ ref class Macro {
 			break;
 			case MacroType::LOOTMACRO:
 				if (MacrosEnabled::bMacroLoot && HelperFuncs::ValidToLoot()) {
-					if (String::IsNullOrWhiteSpace(Timelapse::MainForm::TheInstance->tbLootItem->Text)) break;
-					const int itemCntLootLimit = Convert::ToUInt32(Timelapse::MainForm::TheInstance->tbLootItem->Text);
+					if (String::IsNullOrWhiteSpace(Timelapse::MainForm::TheInstance->tbLootItemCount->Text)) break;
+					const int itemCntLootLimit = Convert::ToUInt32(Timelapse::MainForm::TheInstance->tbLootItemCount->Text);
 					const int itemCntCurrent = ReadPointer(DropPoolBase, OFS_ItemCount);
 
 					if (itemCntCurrent > itemCntLootLimit) {

--- a/Timelapse/Application/MainForm.cpp
+++ b/Timelapse/Application/MainForm.cpp
@@ -710,7 +710,7 @@ void MainForm::tbLootInterval_TextChanged(Object^  sender, EventArgs^  e) {
 	}
 }
 
-void MainForm::tbLootItem_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
+void MainForm::tbLootItemCount_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 
@@ -1475,7 +1475,7 @@ void MainForm::tbSpawnControlY_KeyPress(Object^  sender, Windows::Forms::KeyPres
 void KamiLoop() {
 	while (GlobalRefs::bKami || GlobalRefs::bKamiLoot) {
 		if (GlobalRefs::bKami && GlobalRefs::bKamiLoot) {
-			if(ReadPointer(DropPoolBase, OFS_ItemCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiLootItem->Text)) {
+			if(ReadPointer(DropPoolBase, OFS_ItemCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiLootItemCount->Text)) {
 				if (!GlobalRefs::isChangingField && !GlobalRefs::isMapRushing) {}
 					Teleport(Assembly::ItemX, Assembly::ItemY + 10);
 				Sleep(Convert::ToUInt32(MainForm::TheInstance->tbKamiLootInterval->Text));
@@ -1503,7 +1503,7 @@ void KamiLoop() {
 			Sleep(Convert::ToUInt32(MainForm::TheInstance->tbKamiInterval->Text));
 		}
 		else if (GlobalRefs::bKamiLoot) {
-			if (ReadPointer(DropPoolBase, OFS_ItemCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiLootItem->Text)) {
+			if (ReadPointer(DropPoolBase, OFS_ItemCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiLootItemCount->Text)) {
 				if (!GlobalRefs::isChangingField && !GlobalRefs::isMapRushing) {}
 					Teleport(Assembly::ItemX, Assembly::ItemY+10); //MessageBox::Show("ItemX: " + Assembly::ItemX.ToString() + " ItemY: " + Assembly::ItemY.ToString());
 			}
@@ -1535,7 +1535,7 @@ void MainForm::cbKami_CheckedChanged(System::Object^  sender, System::EventArgs^
 void MainForm::cbKamiLoot_CheckedChanged(System::Object^  sender, System::EventArgs^  e) {
 	if (this->cbKamiLoot->Checked) {
 		tbKamiLootInterval->Enabled = false;
-		tbKamiLootItem->Enabled = false;
+		tbKamiLootItemCount->Enabled = false;
 		GlobalRefs::bKamiLoot = true;
 		cbLoot->Checked = true; //Enable Auto Loot (Required for call to PtInRect)
 		*(ULONG*)PtInRectAddr = (ULONG)Assembly::ItemHook;
@@ -1547,7 +1547,7 @@ void MainForm::cbKamiLoot_CheckedChanged(System::Object^  sender, System::EventA
 		cbLoot->Checked = false; //Disable Auto Loot 
 		*(ULONG*)PtInRectAddr = (ULONG)PtInRect;
 		tbKamiLootInterval->Enabled = true;
-		tbKamiLootItem->Enabled = true;
+		tbKamiLootItemCount->Enabled = true;
 	}
 }
 
@@ -1571,7 +1571,7 @@ void MainForm::tbKamiLootInterval_KeyPress(Object^  sender, Windows::Forms::KeyP
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 
-void MainForm::tbKamiLootItem_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
+void MainForm::tbKamiLootItemCount_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 #pragma endregion

--- a/Timelapse/Application/MainForm.cpp
+++ b/Timelapse/Application/MainForm.cpp
@@ -660,7 +660,7 @@ void MainForm::tbAttackInterval_TextChanged(Object^  sender, EventArgs^  e) {
 	}
 }
 
-void MainForm::tbAttackMob_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
+void MainForm::tbAttackMobCount_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 
@@ -865,7 +865,7 @@ void MainForm::AutoCCCSTimer_Tick(Object^  sender, EventArgs^  e) {
 	}
 
 	if (cbCCCSMob->Checked) {
-		if (ReadPointer(MobPoolBase, OFS_MobCount) < Convert::ToUInt32(tbCCCSMob->Text)) {
+		if (ReadPointer(MobPoolBase, OFS_MobCount) < Convert::ToUInt32(tbCCCSMobCount->Text)) {
 			if (rbCC->Checked) AutoCC(-1);
 			else AutoCS();
 		}
@@ -915,7 +915,7 @@ void MainForm::tbCCCSAttack_KeyPress(Object^  sender, Windows::Forms::KeyPressEv
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 
-void MainForm::tbCCCSMob_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
+void MainForm::tbCCCSMobCount_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 
@@ -1480,7 +1480,7 @@ void KamiLoop() {
 					Teleport(Assembly::ItemX, Assembly::ItemY + 10);
 				Sleep(Convert::ToUInt32(MainForm::TheInstance->tbKamiLootInterval->Text));
 			}
-			else if (ReadPointer(MobPoolBase, OFS_MobCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiMob->Text)) {
+			else if (ReadPointer(MobPoolBase, OFS_MobCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiMobCount->Text)) {
 				POINT telePoint;
 				telePoint.x = ReadMultiPointerSigned(MobPoolBase, 5, OFS_Mob1, OFS_Mob2, OFS_Mob3, OFS_Mob4, OFS_MobX) - Convert::ToInt32(MainForm::TheInstance->tbKamiX->Text);
 				telePoint.y = ReadMultiPointerSigned(MobPoolBase, 5, OFS_Mob1, OFS_Mob2, OFS_Mob3, OFS_Mob4, OFS_MobY) - Convert::ToInt32(MainForm::TheInstance->tbKamiY->Text);
@@ -1492,7 +1492,7 @@ void KamiLoop() {
 			}
 		}
 		else if (GlobalRefs::bKami) {
-			if(ReadPointer(MobPoolBase, OFS_MobCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiMob->Text)) {
+			if(ReadPointer(MobPoolBase, OFS_MobCount) > Convert::ToUInt32(MainForm::TheInstance->tbKamiMobCount->Text)) {
 				POINT telePoint;
 				telePoint.x = ReadMultiPointerSigned(MobPoolBase, 5, OFS_Mob1, OFS_Mob2, OFS_Mob3, OFS_Mob4, OFS_MobX) - Convert::ToInt32(MainForm::TheInstance->tbKamiX->Text);
 				telePoint.y = ReadMultiPointerSigned(MobPoolBase, 5, OFS_Mob1, OFS_Mob2, OFS_Mob3, OFS_Mob4, OFS_MobY) - Convert::ToInt32(MainForm::TheInstance->tbKamiY->Text);
@@ -1518,7 +1518,7 @@ void MainForm::cbKami_CheckedChanged(System::Object^  sender, System::EventArgs^
 		tbKamiX->Enabled = false;
 		tbKamiY->Enabled = false;
 		tbKamiInterval->Enabled = false;
-		tbKamiMob->Enabled = false;
+		tbKamiMobCount->Enabled = false;
 		GlobalRefs::bKami = true;
 		if(!GlobalRefs::bKamiLoot)
 			NewThread(KamiLoop);
@@ -1528,7 +1528,7 @@ void MainForm::cbKami_CheckedChanged(System::Object^  sender, System::EventArgs^
 		tbKamiX->Enabled = true;
 		tbKamiY->Enabled = true;
 		tbKamiInterval->Enabled = true;
-		tbKamiMob->Enabled = true;
+		tbKamiMobCount->Enabled = true;
 	}
 }
 
@@ -1563,7 +1563,7 @@ void MainForm::tbKamiInterval_KeyPress(Object^  sender, Windows::Forms::KeyPress
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 
-void MainForm::tbKamiMob_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
+void MainForm::tbKamiMobCount_KeyPress(Object^  sender, Windows::Forms::KeyPressEventArgs^  e) {
 	if (!isKeyValid(sender, e, false)) e->Handled = true; //If key is not valid, do nothing and indicate that it has been handled
 }
 

--- a/Timelapse/Application/MainForm.h
+++ b/Timelapse/Application/MainForm.h
@@ -155,7 +155,7 @@ private: System::Windows::Forms::Button^  bDupeXGetFoothold;
 	private: System::Windows::Forms::Label^  label56;
 	public: System::Windows::Forms::TextBox^  tbKamiX;
 	private: System::Windows::Forms::Label^  label55;
-	public: System::Windows::Forms::TextBox^  tbKamiMob;
+	public: System::Windows::Forms::TextBox^  tbKamiMobCount;
 	public: System::Windows::Forms::TextBox^  tbKamiInterval;
 	private: System::Windows::Forms::Label^  label53;
 	private: System::Windows::Forms::Label^  label54;
@@ -328,7 +328,7 @@ private:
 	public: System::Windows::Forms::ComboBox^  comboChannelKey;
 	private: System::Windows::Forms::Label^  label47;
 	private: System::Windows::Forms::Panel^  panel7;
-	private: System::Windows::Forms::TextBox^  tbCCCSMob;
+	private: System::Windows::Forms::TextBox^  tbCCCSMobCount;
 	private: System::Windows::Forms::TextBox^  tbCCCSAttack;
 	private: System::Windows::Forms::TextBox^  tbCCCSPeople;
 	private: System::Windows::Forms::TextBox^  tbCCCSTime;
@@ -350,7 +350,7 @@ private:
 	private: System::Windows::Forms::Label^  label31;
 	private: System::Windows::Forms::ComboBox^  comboLootKey;
 	public: System::Windows::Forms::CheckBox^  cbLoot;
-	public: System::Windows::Forms::TextBox^  tbAttackMob;
+	public: System::Windows::Forms::TextBox^  tbAttackMobCount;
 	private: System::Windows::Forms::TextBox^  tbAttackInterval;
 	private: System::Windows::Forms::Label^  label30;
 	private: System::Windows::Forms::Label^  label28;
@@ -606,7 +606,7 @@ public:
 			this->comboChannelKey = (gcnew System::Windows::Forms::ComboBox());
 			this->label47 = (gcnew System::Windows::Forms::Label());
 			this->panel7 = (gcnew System::Windows::Forms::Panel());
-			this->tbCCCSMob = (gcnew System::Windows::Forms::TextBox());
+			this->tbCCCSMobCount = (gcnew System::Windows::Forms::TextBox());
 			this->tbCCCSAttack = (gcnew System::Windows::Forms::TextBox());
 			this->tbCCCSPeople = (gcnew System::Windows::Forms::TextBox());
 			this->tbCCCSTime = (gcnew System::Windows::Forms::TextBox());
@@ -633,7 +633,7 @@ public:
 			this->tbLootItem = (gcnew System::Windows::Forms::TextBox());
 			this->tbAttackInterval = (gcnew System::Windows::Forms::TextBox());
 			this->tbLootInterval = (gcnew System::Windows::Forms::TextBox());
-			this->tbAttackMob = (gcnew System::Windows::Forms::TextBox());
+			this->tbAttackMobCount = (gcnew System::Windows::Forms::TextBox());
 			this->label31 = (gcnew System::Windows::Forms::Label());
 			this->label29 = (gcnew System::Windows::Forms::Label());
 			this->label28 = (gcnew System::Windows::Forms::Label());
@@ -790,7 +790,7 @@ public:
 			this->label56 = (gcnew System::Windows::Forms::Label());
 			this->tbKamiX = (gcnew System::Windows::Forms::TextBox());
 			this->label55 = (gcnew System::Windows::Forms::Label());
-			this->tbKamiMob = (gcnew System::Windows::Forms::TextBox());
+			this->tbKamiMobCount = (gcnew System::Windows::Forms::TextBox());
 			this->tbKamiInterval = (gcnew System::Windows::Forms::TextBox());
 			this->label53 = (gcnew System::Windows::Forms::Label());
 			this->label54 = (gcnew System::Windows::Forms::Label());
@@ -2651,7 +2651,7 @@ public:
 			// panel7
 			// 
 			this->panel7->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
-			this->panel7->Controls->Add(this->tbCCCSMob);
+			this->panel7->Controls->Add(this->tbCCCSMobCount);
 			this->panel7->Controls->Add(this->tbCCCSAttack);
 			this->panel7->Controls->Add(this->tbCCCSPeople);
 			this->panel7->Controls->Add(this->tbCCCSTime);
@@ -2670,19 +2670,19 @@ public:
 			this->panel7->Size = System::Drawing::Size(197, 164);
 			this->panel7->TabIndex = 2;
 			// 
-			// tbCCCSMob
+			// tbCCCSMobCount
 			// 
-			this->tbCCCSMob->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
+			this->tbCCCSMobCount->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
 				static_cast<System::Int32>(static_cast<System::Byte>(35)));
-			this->tbCCCSMob->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
-			this->tbCCCSMob->ForeColor = System::Drawing::Color::White;
-			this->tbCCCSMob->Location = System::Drawing::Point(111, 132);
-			this->tbCCCSMob->Name = L"tbCCCSMob";
-			this->tbCCCSMob->Size = System::Drawing::Size(78, 21);
-			this->tbCCCSMob->TabIndex = 16;
-			this->tbCCCSMob->Text = L"1";
-			this->tbCCCSMob->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbCCCSMob->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbCCCSMob_KeyPress);
+			this->tbCCCSMobCount->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
+			this->tbCCCSMobCount->ForeColor = System::Drawing::Color::White;
+			this->tbCCCSMobCount->Location = System::Drawing::Point(111, 132);
+			this->tbCCCSMobCount->Name = L"tbCCCSMobCount";
+			this->tbCCCSMobCount->Size = System::Drawing::Size(78, 21);
+			this->tbCCCSMobCount->TabIndex = 16;
+			this->tbCCCSMobCount->Text = L"1";
+			this->tbCCCSMobCount->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
+			this->tbCCCSMobCount->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbCCCSMobCount_KeyPress);
 			// 
 			// tbCCCSAttack
 			// 
@@ -2907,7 +2907,7 @@ public:
 			this->panel2->Controls->Add(this->tbLootItem);
 			this->panel2->Controls->Add(this->tbAttackInterval);
 			this->panel2->Controls->Add(this->tbLootInterval);
-			this->panel2->Controls->Add(this->tbAttackMob);
+			this->panel2->Controls->Add(this->tbAttackMobCount);
 			this->panel2->Controls->Add(this->label31);
 			this->panel2->Controls->Add(this->label29);
 			this->panel2->Controls->Add(this->label28);
@@ -3018,19 +3018,19 @@ public:
 			this->tbLootInterval->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
 			this->tbLootInterval->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbLootInterval_KeyPress);
 			// 
-			// tbAttackMob
+			// tbAttackMobCount
 			// 
-			this->tbAttackMob->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
+			this->tbAttackMobCount->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
 				static_cast<System::Int32>(static_cast<System::Byte>(35)));
-			this->tbAttackMob->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
-			this->tbAttackMob->ForeColor = System::Drawing::Color::White;
-			this->tbAttackMob->Location = System::Drawing::Point(132, 53);
-			this->tbAttackMob->Name = L"tbAttackMob";
-			this->tbAttackMob->Size = System::Drawing::Size(28, 21);
-			this->tbAttackMob->TabIndex = 9;
-			this->tbAttackMob->Text = L"0";
-			this->tbAttackMob->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbAttackMob->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbAttackMob_KeyPress);
+			this->tbAttackMobCount->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
+			this->tbAttackMobCount->ForeColor = System::Drawing::Color::White;
+			this->tbAttackMobCount->Location = System::Drawing::Point(132, 53);
+			this->tbAttackMobCount->Name = L"tbAttackMobCount";
+			this->tbAttackMobCount->Size = System::Drawing::Size(28, 21);
+			this->tbAttackMobCount->TabIndex = 9;
+			this->tbAttackMobCount->Text = L"0";
+			this->tbAttackMobCount->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
+			this->tbAttackMobCount->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbAttackMobCount_KeyPress);
 			// 
 			// label31
 			// 
@@ -5035,7 +5035,7 @@ public:
 			this->panel14->Controls->Add(this->label56);
 			this->panel14->Controls->Add(this->tbKamiX);
 			this->panel14->Controls->Add(this->label55);
-			this->panel14->Controls->Add(this->tbKamiMob);
+			this->panel14->Controls->Add(this->tbKamiMobCount);
 			this->panel14->Controls->Add(this->tbKamiInterval);
 			this->panel14->Controls->Add(this->label53);
 			this->panel14->Controls->Add(this->label54);
@@ -5093,19 +5093,19 @@ public:
 			this->label55->TabIndex = 12;
 			this->label55->Text = L"X:";
 			// 
-			// tbKamiMob
+			// tbKamiMobCount
 			// 
-			this->tbKamiMob->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
+			this->tbKamiMobCount->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
 				static_cast<System::Int32>(static_cast<System::Byte>(35)));
-			this->tbKamiMob->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
-			this->tbKamiMob->ForeColor = System::Drawing::Color::White;
-			this->tbKamiMob->Location = System::Drawing::Point(87, 69);
-			this->tbKamiMob->Name = L"tbKamiMob";
-			this->tbKamiMob->Size = System::Drawing::Size(40, 21);
-			this->tbKamiMob->TabIndex = 9;
-			this->tbKamiMob->Text = L"0";
-			this->tbKamiMob->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbKamiMob->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbKamiMob_KeyPress);
+			this->tbKamiMobCount->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
+			this->tbKamiMobCount->ForeColor = System::Drawing::Color::White;
+			this->tbKamiMobCount->Location = System::Drawing::Point(87, 69);
+			this->tbKamiMobCount->Name = L"tbKamiMobCount";
+			this->tbKamiMobCount->Size = System::Drawing::Size(40, 21);
+			this->tbKamiMobCount->TabIndex = 9;
+			this->tbKamiMobCount->Text = L"0";
+			this->tbKamiMobCount->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
+			this->tbKamiMobCount->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbKamiMobCount_KeyPress);
 			// 
 			// tbKamiInterval
 			// 
@@ -6625,7 +6625,7 @@ public:
 	private: System::Void tbHP_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbMP_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbAttackInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
-	private: System::Void tbAttackMob_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
+	private: System::Void tbAttackMobCount_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbLootInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbLootItem_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbAPLevel_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
@@ -6639,7 +6639,7 @@ public:
 	private: System::Void tbCCCSTime_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbCCCSPeople_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbCCCSAttack_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
-	private: System::Void tbCCCSMob_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
+	private: System::Void tbCCCSMobCount_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbCSDelay_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbClickTeleport_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbMouseTeleport_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
@@ -6651,7 +6651,7 @@ public:
 	private: System::Void tbKamiX_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbKamiY_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbKamiInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
-	private: System::Void tbKamiMob_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
+	private: System::Void tbKamiMobCount_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbKamiLootInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbKamiLootItem_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbWallVacX_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);

--- a/Timelapse/Application/MainForm.h
+++ b/Timelapse/Application/MainForm.h
@@ -145,7 +145,7 @@ private: System::Windows::Forms::Button^  bDupeXGetFoothold;
 	private: System::Windows::Forms::Label^  label52;
 	private: System::Windows::Forms::CheckBox^  cbWallVac;
 	private: System::Windows::Forms::Panel^  panel13;
-	public: System::Windows::Forms::TextBox^  tbKamiLootItem;
+	public: System::Windows::Forms::TextBox^  tbKamiLootItemCount;
 	public: System::Windows::Forms::TextBox^  tbKamiLootInterval;
 	private: System::Windows::Forms::Label^  label57;
 	private: System::Windows::Forms::Label^  label58;
@@ -344,7 +344,7 @@ private:
 	private: System::Windows::Forms::CheckBox^  cbCCCSTime;
 	public: System::Windows::Forms::RadioButton^  rbFunction;
 	public: System::Windows::Forms::RadioButton^  rbPacket;
-	public: System::Windows::Forms::TextBox^  tbLootItem;
+	public: System::Windows::Forms::TextBox^  tbLootItemCount;
 	private: System::Windows::Forms::TextBox^  tbLootInterval;
 	private: System::Windows::Forms::Label^  label29;
 	private: System::Windows::Forms::Label^  label31;
@@ -630,7 +630,7 @@ public:
 			this->HPPotDelay = (gcnew System::Windows::Forms::TextBox());
 			this->label93 = (gcnew System::Windows::Forms::Label());
 			this->label91 = (gcnew System::Windows::Forms::Label());
-			this->tbLootItem = (gcnew System::Windows::Forms::TextBox());
+			this->tbLootItemCount = (gcnew System::Windows::Forms::TextBox());
 			this->tbAttackInterval = (gcnew System::Windows::Forms::TextBox());
 			this->tbLootInterval = (gcnew System::Windows::Forms::TextBox());
 			this->tbAttackMobCount = (gcnew System::Windows::Forms::TextBox());
@@ -780,7 +780,7 @@ public:
 			this->label52 = (gcnew System::Windows::Forms::Label());
 			this->cbWallVac = (gcnew System::Windows::Forms::CheckBox());
 			this->panel13 = (gcnew System::Windows::Forms::Panel());
-			this->tbKamiLootItem = (gcnew System::Windows::Forms::TextBox());
+			this->tbKamiLootItemCount = (gcnew System::Windows::Forms::TextBox());
 			this->tbKamiLootInterval = (gcnew System::Windows::Forms::TextBox());
 			this->label57 = (gcnew System::Windows::Forms::Label());
 			this->label58 = (gcnew System::Windows::Forms::Label());
@@ -2904,7 +2904,7 @@ public:
 			this->panel2->Controls->Add(this->HPPotDelay);
 			this->panel2->Controls->Add(this->label93);
 			this->panel2->Controls->Add(this->label91);
-			this->panel2->Controls->Add(this->tbLootItem);
+			this->panel2->Controls->Add(this->tbLootItemCount);
 			this->panel2->Controls->Add(this->tbAttackInterval);
 			this->panel2->Controls->Add(this->tbLootInterval);
 			this->panel2->Controls->Add(this->tbAttackMobCount);
@@ -2976,19 +2976,19 @@ public:
 			this->label91->TabIndex = 11;
 			this->label91->Text = L"Delay[ms]:";
 			// 
-			// tbLootItem
+			// tbLootItemCount
 			// 
-			this->tbLootItem->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
+			this->tbLootItemCount->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
 				static_cast<System::Int32>(static_cast<System::Byte>(35)));
-			this->tbLootItem->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
-			this->tbLootItem->ForeColor = System::Drawing::Color::White;
-			this->tbLootItem->Location = System::Drawing::Point(132, 78);
-			this->tbLootItem->Name = L"tbLootItem";
-			this->tbLootItem->Size = System::Drawing::Size(28, 21);
-			this->tbLootItem->TabIndex = 9;
-			this->tbLootItem->Text = L"0";
-			this->tbLootItem->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbLootItem->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbLootItem_KeyPress);
+			this->tbLootItemCount->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
+			this->tbLootItemCount->ForeColor = System::Drawing::Color::White;
+			this->tbLootItemCount->Location = System::Drawing::Point(132, 78);
+			this->tbLootItemCount->Name = L"tbLootItemCount";
+			this->tbLootItemCount->Size = System::Drawing::Size(28, 21);
+			this->tbLootItemCount->TabIndex = 9;
+			this->tbLootItemCount->Text = L"0";
+			this->tbLootItemCount->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
+			this->tbLootItemCount->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbLootItemCount_KeyPress);
 			// 
 			// tbAttackInterval
 			// 
@@ -4957,7 +4957,7 @@ public:
 			// panel13
 			// 
 			this->panel13->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
-			this->panel13->Controls->Add(this->tbKamiLootItem);
+			this->panel13->Controls->Add(this->tbKamiLootItemCount);
 			this->panel13->Controls->Add(this->tbKamiLootInterval);
 			this->panel13->Controls->Add(this->label57);
 			this->panel13->Controls->Add(this->label58);
@@ -4967,19 +4967,19 @@ public:
 			this->panel13->Size = System::Drawing::Size(132, 70);
 			this->panel13->TabIndex = 7;
 			// 
-			// tbKamiLootItem
+			// tbKamiLootItemCount
 			// 
-			this->tbKamiLootItem->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
+			this->tbKamiLootItemCount->BackColor = System::Drawing::Color::FromArgb(static_cast<System::Int32>(static_cast<System::Byte>(35)), static_cast<System::Int32>(static_cast<System::Byte>(35)),
 				static_cast<System::Int32>(static_cast<System::Byte>(35)));
-			this->tbKamiLootItem->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
-			this->tbKamiLootItem->ForeColor = System::Drawing::Color::White;
-			this->tbKamiLootItem->Location = System::Drawing::Point(87, 42);
-			this->tbKamiLootItem->Name = L"tbKamiLootItem";
-			this->tbKamiLootItem->Size = System::Drawing::Size(40, 21);
-			this->tbKamiLootItem->TabIndex = 9;
-			this->tbKamiLootItem->Text = L"0";
-			this->tbKamiLootItem->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
-			this->tbKamiLootItem->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbKamiLootItem_KeyPress);
+			this->tbKamiLootItemCount->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
+			this->tbKamiLootItemCount->ForeColor = System::Drawing::Color::White;
+			this->tbKamiLootItemCount->Location = System::Drawing::Point(87, 42);
+			this->tbKamiLootItemCount->Name = L"tbKamiLootItemCount";
+			this->tbKamiLootItemCount->Size = System::Drawing::Size(40, 21);
+			this->tbKamiLootItemCount->TabIndex = 9;
+			this->tbKamiLootItemCount->Text = L"0";
+			this->tbKamiLootItemCount->TextAlign = System::Windows::Forms::HorizontalAlignment::Center;
+			this->tbKamiLootItemCount->KeyPress += gcnew System::Windows::Forms::KeyPressEventHandler(this, &MainForm::tbKamiLootItemCount_KeyPress);
 			// 
 			// tbKamiLootInterval
 			// 
@@ -6627,7 +6627,7 @@ public:
 	private: System::Void tbAttackInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbAttackMobCount_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbLootInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
-	private: System::Void tbLootItem_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
+	private: System::Void tbLootItemCount_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbAPLevel_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbAPHP_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbAPMP_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
@@ -6653,7 +6653,7 @@ public:
 	private: System::Void tbKamiInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbKamiMobCount_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbKamiLootInterval_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
-	private: System::Void tbKamiLootItem_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
+	private: System::Void tbKamiLootItemCount_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbWallVacX_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbWallVacY_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);
 	private: System::Void tbWallVacRangeX_KeyPress(System::Object^  sender, System::Windows::Forms::KeyPressEventArgs^  e);


### PR DESCRIPTION
## Summary
- rename the mob-related text boxes to include a Count suffix so their intent is clear
- update all logic and event handlers that reference the renamed controls
- refresh README notes to reflect the new control names

## Testing
- not run (UI rename only)


------
https://chatgpt.com/codex/tasks/task_e_68d6fd15cf4883329900f4073c684ce3