### PR TITLE
Fix packet editor logging

### DIFF
--- a/Timelapse/Infrastructure/Hooks.h
+++ b/Timelapse/Infrastructure/Hooks.h
@@ -5,6 +5,7 @@
 #include "../Core/Packet.h"
 #include "../Libraries/detours.h"
 #include <queue>
+#include <cstring>
 #include "Addresses.h"
 
 #pragma comment(lib, "detours.lib")
@@ -136,23 +137,31 @@ inline bool __stdcall shouldMobBeFiltered() {
 
 static std::queue<COutPacket*> *sendPacketQueue = new std::queue<COutPacket*>();
 inline void __stdcall addSendPacket() {
-	//void* packet = new COutPacket();
-	//memcpy((void*)packet, (void*)sendPacketData->packet, sizeof(COutPacket));
-	COutPacket *packet = new COutPacket();
-	COutPacket *oldPacket = sendPacketData->packet;
+        COutPacket *oldPacket = sendPacketData->packet;
+        if (oldPacket == nullptr) {
+                return;
+        }
 
-	packet->Loopback = oldPacket->Loopback;
-	UCHAR data = *oldPacket->Data;
-	//void unk = *oldPacket->Unk;
-	USHORT header = *oldPacket->Header;
+        COutPacket *packet = new COutPacket();
+        packet->Loopback = oldPacket->Loopback;
+        packet->Size = oldPacket->Size;
+        packet->Offset = oldPacket->Offset;
+        packet->EncryptedByShanda = oldPacket->EncryptedByShanda;
 
-	packet->Data = &data;
-	packet->Unk = oldPacket->Unk;
-	packet->Header = &header;
-	packet->Size = oldPacket->Size;
-	packet->Offset = oldPacket->Offset;
-	packet->EncryptedByShanda = oldPacket->EncryptedByShanda;
-	sendPacketQueue->push(packet);
+        if (oldPacket->Size > 0 && oldPacket->Data != nullptr) {
+                PUCHAR dataCopy = new UCHAR[oldPacket->Size];
+                memcpy(dataCopy, oldPacket->Data, oldPacket->Size);
+                packet->Data = dataCopy;
+                packet->Unk = dataCopy;
+                packet->Header = reinterpret_cast<PUSHORT>(dataCopy);
+        }
+        else {
+                packet->Data = nullptr;
+                packet->Unk = nullptr;
+                packet->Header = nullptr;
+        }
+
+        sendPacketQueue->push(packet);
 }
 
 #pragma unmanaged


### PR DESCRIPTION
## Summary
- deep copy outgoing packets before queueing so the packet editor can read their contents safely
- expand the packet log tick handler to flush all queued packets, log payloads, and show them in the UI tree view
- dispose of queued packet buffers after use to avoid leaking memory during logging

## Testing
- not run (Windows-only project)


------
https://chatgpt.com/codex/tasks/task_e_68d7013f447883328a5e2fb6580748a0