### PR TITLE
Guard auto HP/MP toggles against null macros

### DIFF
--- a/Timelapse/Application/MainForm.Bots.cpp
+++ b/Timelapse/Application/MainForm.Bots.cpp
@@ -49,7 +49,8 @@ void MainForm::cbHP_CheckedChanged(Object ^ sender, EventArgs ^ e) {
         GlobalRefs::macroHP->Toggle(true);
         MacrosEnabled::bMacroHP = true;
     } else {
-        GlobalRefs::macroHP->Toggle(false);
+        if (GlobalRefs::macroHP != nullptr)
+            GlobalRefs::macroHP->Toggle(false);
         MacrosEnabled::bMacroHP = false;
     }
 }
@@ -83,7 +84,8 @@ void MainForm::cbMP_CheckedChanged(Object ^ sender, EventArgs ^ e) {
         GlobalRefs::macroMP->Toggle(true);
         MacrosEnabled::bMacroMP = true;
     } else {
-        GlobalRefs::macroMP->Toggle(false);
+        if (GlobalRefs::macroMP != nullptr)
+            GlobalRefs::macroMP->Toggle(false);
         MacrosEnabled::bMacroMP = false;
     }
 }


### PR DESCRIPTION
## Summary
- guard the auto HP and MP toggle handlers against null macro instances before disabling them

## Testing
- not run (not supported)


------
https://chatgpt.com/codex/tasks/task_e_68d70dcd1de88332956cb243e13ab773