### PR TITLE
Fix CodeCave macro assembly formatting

### DIFF
--- a/Timelapse/Infrastructure/Assembly.h
+++ b/Timelapse/Infrastructure/Assembly.h
@@ -8,9 +8,9 @@
 #include <cstring>
 
 #pragma comment(lib, "detours.lib")
-#define CodeCave(name)                      \
-    static void __declspec(naked)##name() { \
-        _asm
+#define CodeCave(name)                          \
+    static void __declspec(naked) name() {      \
+        __asm {
 #define EndCodeCave }
 
 bool SetHook(bool enable, void** function, void* redirection) {

--- a/Timelapse/Infrastructure/Hooks.h
+++ b/Timelapse/Infrastructure/Hooks.h
@@ -9,9 +9,9 @@
 #include "Addresses.h"
 
 #pragma comment(lib, "detours.lib")
-#define CodeCave(name)                      \
-    static void __declspec(naked)##name() { \
-        _asm
+#define CodeCave(name)                          \
+    static void __declspec(naked) name() {      \
+        __asm {
 #define EndCodeCave }
 
 // Set Hook for function


### PR DESCRIPTION
## Summary
- correct the CodeCave macro to use a properly spaced naked function declaration
- switch inline assembly blocks to the modern __asm form for consistent formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70ff9c9e88332ba67b732d0c0b061