### PR TITLE
Mark inline definitions to fix duplicate symbol linker errors

### DIFF
--- a/Timelapse/Application/Macros/Macro.h
+++ b/Timelapse/Application/Macros/Macro.h
@@ -9,7 +9,7 @@
 
 using Timelapse::Logging::Log;
 
-bool DBG_Macro = false;
+inline bool DBG_Macro = false;
 enum class MacroType {
     LOOTMACRO = 1,
     ATTACKMACRO = 2,

--- a/Timelapse/Infrastructure/Hooks.h
+++ b/Timelapse/Infrastructure/Hooks.h
@@ -469,7 +469,7 @@ CodeCave(StatHook)
 
 namespace Hooks {
 // For botting
-bool CUserLocal__Update_Hook(bool enable) {
+inline bool CUserLocal__Update_Hook(bool enable) {
     typedef void(__stdcall * pfnCUserLocal__Update)(PVOID, PVOID);
     static auto CUserLocal__Update = reinterpret_cast<pfnCUserLocal__Update>(userlocalUpdateAddr);
 
@@ -480,7 +480,7 @@ bool CUserLocal__Update_Hook(bool enable) {
     return SetHook(enable, reinterpret_cast<void**>(&CUserLocal__Update), hook);
 }
 
-bool ChangeChannel(int channel) {
+inline bool ChangeChannel(int channel) {
     typedef int(__stdcall * pfnCField__SendTransferChannelRequest)(int nTargetChannel); // Changes Channel
     static auto CField__SendTransferChannelRequest = reinterpret_cast<pfnCField__SendTransferChannelRequest>(ccAddr);
 
@@ -500,7 +500,7 @@ bool ChangeChannel(int channel) {
     return false;
 }
 
-bool CLogin__OnRecommendWorldMessage_Hook(bool enable) {
+inline bool CLogin__OnRecommendWorldMessage_Hook(bool enable) {
     typedef void(__stdcall * pfnCLogin__OnRecommendWorldMessage)(PVOID, PVOID);
     static pfnCLogin__OnRecommendWorldMessage CLogin__OnRecommendWorldMessage = reinterpret_cast<pfnCLogin__OnRecommendWorldMessage>(cloginOnRecommendWorldAddr);
 

--- a/Timelapse/Infrastructure/MapleFunctions.h
+++ b/Timelapse/Infrastructure/MapleFunctions.h
@@ -71,7 +71,7 @@ static void Teleport(POINT point) {
 #pragma endregion
 
 namespace PointerFuncs {
-bool isHooksEnabled = true; // For the future, disable pointers that requires Codecaves or function calls
+inline bool isHooksEnabled = true; // For the future, disable pointers that requires Codecaves or function calls
 
 // Retrieve Char Level
 static String ^ getCharLevel() {


### PR DESCRIPTION
## Summary
- declare the hook functions defined in Hooks.h as inline so they have a single definition across translation units
- mark the debug macro flag and hooks-enabled flag in headers as inline variables to prevent duplicate globals at link time

## Testing
- not run (Windows-specific build environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9773c6a808332b8127865c888c8a7