### PR TITLE
Fix DllMain thread startup to prevent injection crash

### DIFF
--- a/Timelapse/Application/MainForm/MainForm.cpp
+++ b/Timelapse/Application/MainForm/MainForm.cpp
@@ -9,6 +9,7 @@ using namespace System::IO;
 
 // Forward declarations
 void AutoLogin();
+DWORD WINAPI MainThreadProc(LPVOID lpParameter);
 #pragma region General Form
 [STAThread] void Main() {
     Application::EnableVisualStyles();
@@ -16,17 +17,27 @@ void AutoLogin();
     Application::Run(gcnew MainForm);
     Application::Exit();
 }
+
+DWORD WINAPI MainThreadProc(LPVOID lpParameter) {
+    UNREFERENCED_PARAMETER(lpParameter);
+
+    Main();
+    return 0;
+}
 #pragma unmanaged
 BOOL WINAPI DllMain(HMODULE hModule, DWORD dwReason, PVOID lpvReserved) {
     GlobalVars::hDLL = hModule;
 
     switch (dwReason) {
     case DLL_PROCESS_ATTACH:
-        // GlobalVars::hDLL = hModule;
-        CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)&Main, nullptr, 0, nullptr);
+        DisableThreadLibraryCalls(hModule);
+
+        if (HANDLE threadHandle = CreateThread(nullptr, 0, MainThreadProc, nullptr, 0, nullptr)) {
+            CloseHandle(threadHandle);
+        }
         break;
     case DLL_PROCESS_DETACH:
-        FreeLibraryAndExitThread(hModule, 0);
+        break;
     case DLL_THREAD_ATTACH:
         break;
     case DLL_THREAD_DETACH:


### PR DESCRIPTION
## Summary
- add a native-thread-compatible entry point that wraps the managed `Main` startup
- ensure the attach routine disables thread notifications and closes the bootstrap thread handle
- avoid calling FreeLibraryAndExitThread during detach to prevent crashes during injection

## Testing
- Not run (non-Windows build/test environment)

------
https://chatgpt.com/codex/tasks/task_e_68d97b9903f88332aec54831ab559f38