### PR TITLE
Implement receive packet logging toggle

### DIFF
--- a/Timelapse/Application/MainForm/Designer.cpp
+++ b/Timelapse/Application/MainForm/Designer.cpp
@@ -5333,6 +5333,7 @@ using namespace Timelapse;
         this->bRecvLog->TabIndex = 22;
         this->bRecvLog->Text = L"Enable Log";
         this->bRecvLog->UseVisualStyleBackColor = true;
+        this->bRecvLog->Click += gcnew System::EventHandler(this, &MainForm::bRecvLog_Click);
         //
         // bRecvClear
         //

--- a/Timelapse/Application/MainForm/EventHandlers.h
+++ b/Timelapse/Application/MainForm/EventHandlers.h
@@ -254,6 +254,9 @@
     System::Void bRecvPacket_Click(System::Object ^ sender, System::EventArgs ^ e);
 
   private:
+    System::Void bRecvLog_Click(System::Object ^ sender, System::EventArgs ^ e);
+
+  private:
     System::Void cbBlinkGodmode_CheckedChanged(System::Object ^ sender, System::EventArgs ^ e);
 
   private:

--- a/Timelapse/Core/Packet.h
+++ b/Timelapse/Core/Packet.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Windows.h>
+#include <vector>
 
 using namespace System;
 
@@ -13,3 +14,12 @@ void writeString(String ^ % packet, String ^ str);
 void writeInt(String ^ % packet, int num);
 void writeShort(String ^ % packet, short num);
 void writeUnsignedShort(String ^ % packet, USHORT num);
+
+namespace Timelapse {
+namespace PacketLogging {
+bool SetRecvLoggingEnabled(bool enable);
+bool IsRecvLoggingEnabled();
+bool TryDequeueRecvPacket(std::vector<unsigned char>& packetBytes);
+void ClearRecvPacketQueue();
+} // namespace PacketLogging
+} // namespace Timelapse


### PR DESCRIPTION
## Summary
- add detour-based receive packet logging infrastructure and queue management
- expose PacketLogging helpers and hook receive logging from the packets tab
- surface captured receive packets in the UI alongside existing send logging

## Testing
- not run (environment lacks required tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d99dfee40c8332bcc9af322d059551