### PR TITLE
Refine packet editor removal behavior

### DIFF
--- a/Timelapse/Application/MainForm/Designer.cpp
+++ b/Timelapse/Application/MainForm/Designer.cpp
@@ -5170,6 +5170,7 @@ using namespace Timelapse;
         this->bSendRemove->TabIndex = 18;
         this->bSendRemove->Text = L"Remove";
         this->bSendRemove->UseVisualStyleBackColor = true;
+        this->bSendRemove->Click += gcnew System::EventHandler(this, &MainForm::bSendRemove_Click);
         //
         // lvSendBlock
         //
@@ -5231,6 +5232,7 @@ using namespace Timelapse;
         this->bSendClear->TabIndex = 13;
         this->bSendClear->Text = L"Clear";
         this->bSendClear->UseVisualStyleBackColor = true;
+        this->bSendClear->Click += gcnew System::EventHandler(this, &MainForm::bSendClear_Click);
         //
         // bSendPacket
         //
@@ -5284,6 +5286,7 @@ using namespace Timelapse;
         this->bRecvRemove->TabIndex = 26;
         this->bRecvRemove->Text = L"Remove";
         this->bRecvRemove->UseVisualStyleBackColor = true;
+        this->bRecvRemove->Click += gcnew System::EventHandler(this, &MainForm::bRecvRemove_Click);
         //
         // lvRecvBlock
         //
@@ -5344,6 +5347,7 @@ using namespace Timelapse;
         this->bRecvClear->TabIndex = 21;
         this->bRecvClear->Text = L"Clear";
         this->bRecvClear->UseVisualStyleBackColor = true;
+        this->bRecvClear->Click += gcnew System::EventHandler(this, &MainForm::bRecvClear_Click);
         //
         // bRecvPacket
         //

--- a/Timelapse/Application/MainForm/EventHandlers.h
+++ b/Timelapse/Application/MainForm/EventHandlers.h
@@ -254,6 +254,18 @@
     System::Void bRecvPacket_Click(System::Object ^ sender, System::EventArgs ^ e);
 
   private:
+    System::Void bSendRemove_Click(System::Object ^ sender, System::EventArgs ^ e);
+
+  private:
+    System::Void bSendClear_Click(System::Object ^ sender, System::EventArgs ^ e);
+
+  private:
+    System::Void bRecvRemove_Click(System::Object ^ sender, System::EventArgs ^ e);
+
+  private:
+    System::Void bRecvClear_Click(System::Object ^ sender, System::EventArgs ^ e);
+
+  private:
     System::Void cbBlinkGodmode_CheckedChanged(System::Object ^ sender, System::EventArgs ^ e);
 
   private:


### PR DESCRIPTION
## Summary
- update the packet log tree removal helper to cleanly update selection and handle empty parent headers
- guard tree modifications with try/finally blocks so EndUpdate is always reached and selection stays visible
- clear actions now also reset the packet tree selection state

## Testing
- not run (reason: no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d99e235fa083329c605895420296c5